### PR TITLE
Fixed failure on jdk path

### DIFF
--- a/Spark-Docker/cda-spark-lambda/spark-class
+++ b/Spark-Docker/cda-spark-lambda/spark-class
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-exec /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.302.b08-0.amzn2.0.1.x86_64/jre/bin/java -cp /var/lang/lib/python3.8/site-packages/pyspark/conf/:/var/lang/lib/python3.8/site-packages/pyspark/jars/* -Xmx1g "$@"
+exec ${JAVA_HOME}/bin/java -cp /var/lang/lib/python3.8/site-packages/pyspark/conf/:/var/lang/lib/python3.8/site-packages/pyspark/jars/* -Xmx1g "$@"


### PR DESCRIPTION
my java path got installed in /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.312.b07-1.amzn2.0.2.x86_64/jre which broke the path to spark-class,